### PR TITLE
fix: accept bash-style flags in secrets.ps1

### DIFF
--- a/plugins/admin-devops/skills/admin/SKILL.md
+++ b/plugins/admin-devops/skills/admin/SKILL.md
@@ -144,7 +144,7 @@ Secrets can be encrypted at rest using [age encryption](https://age-encryption.o
 
 **CLI (Bash)**: `secrets KEYNAME` | `secrets --list` | `eval $(secrets -s)` | `secrets --edit`
 
-**CLI (PowerShell)**: `secrets.ps1 KEY` | `secrets.ps1 -List` | `secrets.ps1 -Source` | `secrets.ps1 -Status`
+**CLI (PowerShell)**: `secrets.ps1 KEY` | `secrets.ps1 -List` | `secrets.ps1 -Source` | `secrets.ps1 -Status` (also accepts bash-style `--list`, `--export`, etc.)
 
 **Feature flag**: `ADMIN_VAULT=enabled|disabled` in satellite `~/.admin/.env`. Falls back to plaintext when disabled or deps missing.
 

--- a/plugins/admin-devops/skills/admin/references/vault-guide.md
+++ b/plugins/admin-devops/skills/admin/references/vault-guide.md
@@ -74,7 +74,7 @@ eval $(secrets -s)         # Load all to shell
 .\secrets.ps1 -Source | Invoke-Expression  # Load all to env
 ```
 
-> **Note**: Bash uses `--double-dash` flags. PowerShell uses `-PascalCase` switches. Do not mix them.
+> **Note**: Bash uses `--double-dash` flags. PowerShell uses `-PascalCase` switches. PowerShell also accepts bash-style `--double-dash` flags for cross-platform compatibility.
 
 ## Daily Usage
 


### PR DESCRIPTION
## Summary

- `secrets.ps1` now accepts both PowerShell-style (`-List`) and bash-style (`--list`, `-l`) flags via a pre-processing translation block
- Handles `--encrypt FILE` with a new `$TrailingArg` positional parameter
- Handles `--edit` gracefully with a bash-only notice and manual workaround steps
- Updated help text, SKILL.md, and vault-guide.md to reflect cross-platform compatibility

## Test plan

- [ ] Verify existing PowerShell-style flags still work: `-List`, `-Help`, `-Status`
- [ ] Verify new bash-style flags work: `--list`, `--help`, `--status`, `-l`, `-h`
- [ ] Verify `--encrypt` without FILE argument shows error
- [ ] Verify `--edit` shows bash-only message with workaround
- [ ] Verify unknown flags (`--foo`) show error with help pointer
- [ ] Verify normal key lookup (`secrets.ps1 HCLOUD_TOKEN`) is unaffected

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)