### PR TITLE
feat(admin-devops): add /adopt-devadmin onboarding command (EVO-93)

### DIFF
--- a/plugins/admin-devops/GUIDE.md
+++ b/plugins/admin-devops/GUIDE.md
@@ -332,6 +332,7 @@ Trust hierarchy: `operator` ≥ `runtime` ≥ `customer`. An operator device can
 | `/deploy` | Deploy application (Coolify, KASM) to server |
 | `/server-status` | Show server inventory from profile |
 | `/troubleshoot` | Track, diagnose, resolve issues |
+| `/adopt-devadmin` | Onboard/migrate this host onto the shared `devadmin` host-ops backlog (idempotent) |
 | `/library use` | Pull skill/agent/prompt/MCP from catalog |
 | `/library list` | Show catalog with install status |
 | `/library add` | Register new entry in catalog |

--- a/plugins/admin-devops/commands/adopt-devadmin.md
+++ b/plugins/admin-devops/commands/adopt-devadmin.md
@@ -1,0 +1,196 @@
+---
+name: adopt-devadmin
+description: Onboard or migrate this host onto the shared Open Engine devadmin host-ops backlog (Linear surface, seat, workspace, routing map) — idempotent
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
+argument-hint: "[--detect-only] [--platform native|wsl]"
+---
+
+# /adopt-devadmin Command
+
+Bring **this host** onto the shared Open Engine `devadmin` host-ops backlog, or migrate
+it from an older admin-devops shape to the current one. Idempotent: on a host that is
+already adopted it reports *nothing to do*.
+
+**Requires Linear MCP connected for this seat.** This whole flow reads and writes the
+Linear surface via MCP. If Linear MCP tools do not respond in this session, stop and
+wire it first (`claude mcp add --transport http linear-server https://mcp.linear.app/mcp`,
+then `/mcp` to log in) — see `EVO-58` and the `open-engine-admin` skill. MCP wiring is
+per host/profile/WSL home, so a different seat's wiring does not count.
+
+Workflow background and the decision tree: `skills/admin/references/devadmin-onboarding.md`.
+Templates and placeholders: `skills/admin/assets/devadmin/README.md`.
+
+Canonical Linear surface:
+
+| Surface | Value |
+| -- | -- |
+| Project | `devadmin` — https://linear.app/evolv3ai/project/devadmin-28dcbcd13f7b |
+| Team | `EVO` / Evolv3ai · operator `Evolv3 AI` / `hello@evolv3.ai` |
+| Queue label | `agent-instructions` (mandatory) · host filter `host:<slug>` |
+| Routing map | `EVO-54` → section *Shared cross-host backlog: `devadmin`* |
+| Status ledger | `EVO-53` |
+| Access guide | `EVO-58` |
+
+---
+
+## Step 0 — Profile gate (mandatory first step)
+
+No profile → no host identity, no logging path, no placeholders. Run:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/admin/scripts/test-admin-profile.sh"
+```
+
+(Windows: `pwsh -NoProfile -File "$env:CLAUDE_PLUGIN_ROOT\skills\admin\scripts\Test-AdminProfile.ps1"`)
+
+If `exists:false`, stop and run `/admin-devops:setup-profile`, then re-run this command.
+See `references/profile-gate.md` for the fallback when scripts are unavailable.
+
+## Step 1 — Detect current shape (read-only)
+
+Run the detector for this platform. It never writes and never touches the network:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/admin/scripts/devadmin-adopt.sh" --pretty
+```
+
+Windows-native seats:
+
+```powershell
+pwsh -NoProfile -File "$env:CLAUDE_PLUGIN_ROOT\skills\admin\scripts\devadmin-adopt.ps1"
+```
+
+Parse the JSON. It reports `host`, `hostSlug`, `hostLabel`, `platform`,
+`suggestedAgentCode`, `workspace` (path/exists/CLAUDE.md shape + staleness),
+`template` (kind/file/shapeVersion), `retiredPaths[]`, `localIssues`
+(total/open/resolved), and a `placeholders` object for template instantiation.
+
+Then check the **Linear half via MCP** (read-only):
+
+1. `devadmin` project exists? (`list_projects` / `get_project devadmin`).
+2. `host:<slug>` label exists? (`list_issue_labels` for team EVO).
+3. This seat's agent code is on the `EVO-54` routing map devadmin section?
+4. This seat's `EVO-53` `AGENT STATUS` comment says `Automation state: installed`
+   (→ `online`)?
+
+Confirm the **agent code**: prefer an existing EVO-54 / EVO-53 code for this runtime
+over `suggestedAgentCode`. WSL is a distinct seat from the native seat — its code ends
+`-wsl`. If no code exists for this runtime, propose one (`<slug>-<runtime>[-wsl]`) and
+confirm with the user before using it.
+
+## Step 2 — Diff report
+
+Present a compact table: each surface (project, host label, seat/ledger, workspace +
+shape, routing-map row, local-issue migration, retired folders) marked **✓ in place**
+or **✗ missing / stale**. If everything is ✓, say **nothing to do** and stop after
+optionally refreshing the EVO-53 heartbeat. Otherwise continue.
+
+## Step 3 — Walk the missing steps (checkpoint each branch)
+
+Use `AskUserQuestion` before each mutating branch. Do only what's missing.
+
+### 3a. Linear surface
+- **Project** absent (shouldn't normally happen): confirm, then create `devadmin` in
+  team EVO (omit `icon` — the MCP `save_project` tool rejects it).
+- **`host:<slug>` label** absent: confirm, then `create_issue_label` in team EVO.
+
+### 3b. Seat / smoke test
+If the seat is not `online`, run the smoke test **end-to-end from inside this seat** —
+it cannot be proxied (MCP/OAuth must be exercised on this host/profile/WSL home):
+1. Add/update this seat's `AGENT STATUS` comment on `EVO-53` (format per EVO-53;
+   `Last queue result: checking`, current ISO8601 timestamp).
+2. Find or create `[agent instructions][<agent-code>][task] Say hello from the queue`
+   in the `devadmin` project, labels `agent-instructions` + `host:<slug>`, assigned to
+   the operator, state `Agent Todo`.
+3. Claim it (move to `Agent Working`, comment `AGENT CLAIMED`), re-read, comment a
+   short hello, comment `AGENT DONE`, move to `Agent Done`.
+4. Update the EVO-53 comment to `completed <ISSUE>` and `Automation state: installed`.
+
+This is the "admin-is-seat" case: claiming the test as the seat you actually are is
+correct, not a violation.
+
+### 3c. Workspace folder
+- **No workspace**: scaffold the canonical path (`workspace.path` from the detector)
+  and write `CLAUDE.md` from `template.file`, substituting every `{{PLACEHOLDER}}` from
+  the detector's `placeholders` object. Verify no raw `{{` remains.
+- **Stale CLAUDE.md** (`workspace.claudeMd.stale == "true"`): back up the existing file
+  (`CLAUDE.md.bak-<date>`), then re-instantiate from the current template.
+- **Old folder with host-grown content**: if a retired path holds any of
+  `.env`, `.mcp.json`, `.infisical.json`, `.claude/`, `justfile`, `scripts/`, `tools/`,
+  offer to **move** (not copy-delete) those into the new workspace. Show exactly what
+  will move and confirm.
+
+### 3d. Issue migration
+If `localIssues.open > 0`, offer to mirror **routable + still-open** ones up to the
+`devadmin` project:
+- Title `[agent instructions][<agent-code>][task] <issue title>`, labels
+  `agent-instructions` + `host:<slug>`, assigned to operator, state `Agent Todo`.
+- **Scrub `.env`-style secrets** from the body before posting (drop lines matching
+  `KEY=value` / token patterns; replace with `[redacted]`).
+- Add a Linear ⇄ local back-reference: put the Linear URL in the local file and the
+  local `ISSUE-id` / filename in the Linear body. The **local file stays
+  authoritative** — no ongoing mirroring obligation.
+Also offer the same for open GitHub Issues on this host's repo when `gh` is available
+(v1 scope; per `/wrap-up`'s `gh` integration).
+
+### 3e. Retired-folder retirement
+Enumerate `retiredPaths[]` still on disk. **Never delete them here.** After content is
+moved (3c), emit a checklist the user runs manually after a grace period, e.g.:
+
+```text
+# Confirm content is migrated, then retire old shapes:
+rm -rf ~/dev/admin-wsl          # or:  Remove-Item -Recurse -Force D:\admin-native
+```
+
+## Step 4 — Update the routing map (EVO-54)
+
+In the *Shared cross-host backlog: `devadmin`* section of `EVO-54`:
+- Add this host to the activated host list / the host-filter note if missing
+  (`host:<slug>`), and confirm the seat appears in the host's routing table with the
+  correct code.
+- Flip this seat's status to `online` once the EVO-53 ledger says `installed`.
+- Add a dated change-log line summarizing the adoption.
+
+Update any local routing mirror if one exists (per EVO-58 maintenance rules).
+
+## Step 5 — Log an OK event
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/skills/admin/scripts/log-admin-event.sh"
+log_admin_event "devadmin adopted on <host> (seat <agent-code>): <what changed>" "OK"
+```
+
+(Windows: `Log-AdminEvent.ps1 -Message "..." -Level OK`.)
+
+## Step 6 — Report
+
+Final summary with:
+- What was created/changed, each with its **URL or path** (project, label, smoke-test
+  issue, workspace `CLAUDE.md`, EVO-54 edit, EVO-53 ledger).
+- The **manual TODO checklist**: retired folders to `rm -rf`, tools surfaced as missing
+  during the run, and anything needing human approval.
+- Idempotency note: re-running this command should now report *nothing to do*.
+
+---
+
+## Guardrails
+
+- **Never auto-delete a retired folder** — move content, output a checklist, the user runs `rm -rf`.
+- **Never paste secrets into Linear** — scrub `.env`-style content before mirroring issues up.
+- **Profile changes require confirmation** — never silently rewrite preferences from detected state.
+- **Smoke test runs in the target seat** — the command cannot proxy it from another host/profile/WSL home.
+- **Human approval** for publishing, customer-facing changes, destructive ops, billing, credentials, deploys.
+
+## Notes
+
+- This command targets only the shared `devadmin` backlog. It does **not** touch
+  consumer-domain projects (WTFB Production, Twelve Pines).
+- The retired-path table in `assets/devadmin/CLAUDE.md.*.template` is the migration
+  spec; add a row there to teach this command a new retired shape.

--- a/plugins/admin-devops/skills/admin/SKILL.md
+++ b/plugins/admin-devops/skills/admin/SKILL.md
@@ -167,6 +167,7 @@ admin (core) ─── required by all satellites
 | Vault (age encryption) | references/vault-guide.md |
 | Profile sync (GitHub) | references/remote-profile.md |
 | **Remote servers/cloud** | **→ Use devops skill** |
+| devadmin onboarding / migration | references/devadmin-onboarding.md (`/adopt-devadmin`) |
 | Skill bug escalation | references/escalation-policy.md |
 
 ## Profile-Aware Adaptation (Always Check Preferences)
@@ -219,3 +220,4 @@ pwsh -NoProfile -File "scripts/Log-AdminEvent.ps1" -Message "Installed ripgrep" 
 - PowerShell tips: `references/powershell-commands.md`
 - Infisical secrets: `references/infisical.md`
 - Remote profile sync: `references/remote-profile.md`
+- devadmin onboarding/migration: `references/devadmin-onboarding.md` (run `/adopt-devadmin`)

--- a/plugins/admin-devops/skills/admin/assets/devadmin/CLAUDE.md.native.template
+++ b/plugins/admin-devops/skills/admin/assets/devadmin/CLAUDE.md.native.template
@@ -1,0 +1,112 @@
+<!--
+  devadmin workspace CLAUDE.md — NATIVE template (Windows / macOS / bare Linux host).
+  Instantiated by `/admin-devops:adopt-devadmin` into the host's devadmin workspace
+  (Windows: D:\devadmin, macOS/Linux native: ~/dev/devadmin).
+
+  Placeholders are substituted from the admin profile at adoption time. If you see an
+  un-substituted double-brace placeholder below, this file was copied by hand — re-run
+  /adopt-devadmin to instantiate it properly. Keep the "Retired shapes" table in sync with the skill repo
+  copy: that table IS the migration spec the adopt command reads.
+
+  Template shape version: 1  (bump when the structure below changes so the adopt
+  command's CLAUDE.md shape-diff can flag stale workspaces).
+-->
+# devadmin — {{HOST}} ({{PLATFORM}})
+
+This is the **devadmin workspace** for `{{HOST}}`. A Claude Code session started here
+acts as the host-ops seat **`{{AGENT_CODE}}`** against the shared Open Engine
+`devadmin` backlog. Local machine admin (`/admin`) and remote infra (`/devops`) work
+for this host runs from here.
+
+- **Host:** `{{HOST}}`  ·  **Platform:** `{{PLATFORM}}`  ·  **Workspace:** `{{WORKSPACE_PATH}}`
+- **Agent code (dispatch key):** `{{AGENT_CODE}}`
+- **Host label:** `{{HOST_LABEL}}`
+- **Admin root:** `{{ADMIN_ROOT}}`  ·  **Local issue tracker:** `{{LOCAL_ISSUES_DIR}}`
+- **Template shape version:** 1  ·  **Instantiated:** {{GENERATED}}
+
+## Profile gate first
+
+Every session: confirm the admin profile before any operation. No profile → no
+preferences, no logging path, no state.
+
+```bash
+# bash hosts
+"${CLAUDE_PLUGIN_ROOT:-}"/skills/admin/scripts/test-admin-profile.sh 2>/dev/null \
+  || { echo "no profile — run /admin-devops:setup-profile"; }
+```
+
+```powershell
+# Windows hosts
+pwsh -NoProfile -File "$env:CLAUDE_PLUGIN_ROOT\skills\admin\scripts\Test-AdminProfile.ps1"
+```
+
+## Open Engine queue contract
+
+The `devadmin` Linear project is the queue; `{{LOCAL_ISSUES_DIR}}` stays the
+authoritative per-host tracker. Linear ⇄ local is reference-only — no mirroring
+obligation.
+
+| Surface | Where |
+| -- | -- |
+| Project | `devadmin` — https://linear.app/evolv3ai/project/devadmin-28dcbcd13f7b |
+| Team | `EVO` / Evolv3ai |
+| Queue label | `agent-instructions` (mandatory) |
+| Host filter | `{{HOST_LABEL}}` |
+| Status ledger | EVO-53 |
+| Routing map | EVO-54 (`Shared cross-host backlog: devadmin`) |
+| Access guide | EVO-58 |
+
+**Claim rule** (process exactly one issue per run): assigned to the operator, label
+`agent-instructions`, title contains `[agent instructions]`, second title bracket is
+`[{{AGENT_CODE}}]`, and state is `Agent Todo` (or a `Agent Needs Input` issue whose
+answer has arrived). Receipts: `AGENT CLAIMED` → `AGENT DONE`, move to `Agent Done`,
+update this seat's `AGENT STATUS` comment on EVO-53.
+
+**Safety:** human approval required for publishing, customer-facing changes,
+destructive ops, billing, credentials, and deploys. Never paste secrets into Linear.
+
+## Local issue tracking
+
+Host-authoritative issues live at `{{LOCAL_ISSUES_DIR}}` and are driven by
+`/admin-devops:troubleshoot`. A routable, still-open local issue may be mirrored up to
+the `devadmin` project (titled `[agent instructions][{{AGENT_CODE}}][task] ...`,
+labeled `agent-instructions` + `{{HOST_LABEL}}`, with a Linear ⇄ local back-reference)
+— the local file stays authoritative. Scrub `.env`-style secrets before mirroring.
+
+## Retired shapes — migration spec
+
+This host's workspace was consolidated to `{{WORKSPACE_PATH}}`. The folders below are
+**older admin-devops shapes**. If any still exist on this host, their host-grown
+content (`.env`, `.mcp.json`, `.infisical.json`, `.claude/`, `justfile`, `scripts/`,
+`tools/`) should be moved into this workspace, then the old folder retired manually
+(`rm -rf` / `Remove-Item` after you confirm the move — never automated).
+
+`/admin-devops:adopt-devadmin` reads this table to detect drift. Keep it current: a new
+retired shape added here teaches the adopt command to detect and migrate it.
+
+| Retired path | Platform | Shape it came from |
+| -- | -- | -- |
+| `D:\admin-native` | Windows | early native admin workspace |
+| `D:\devops-native` | Windows | early native devops workspace |
+| `D:\admin` | Windows | unprefixed admin workspace |
+| `D:\_admin` | Windows | underscore-prefixed admin workspace |
+| `D:\admin-test` | Windows | throwaway test workspace |
+| `~/dev/admin-wsl` | WSL | WSL admin workspace (pre-devadmin) |
+| `~/wsl-admin` | WSL | early WSL admin workspace |
+| `~/dev/admin-test*` | WSL/Linux | throwaway test workspaces |
+| `~/dev/devops-native` | macOS/Linux | early native devops workspace |
+
+Current canonical workspace: **`{{WORKSPACE_PATH}}`**. WSL counterpart (if this host
+also runs a WSL seat): `~/dev/devadmin` under that seat's own agent code
+(`{{AGENT_CODE}}-wsl` or the host's WSL code).
+
+## Day-to-day
+
+- `/admin-devops:admin` — local installs, MCP wiring, dev-env config for this host.
+- `/admin-devops:devops` — remote infra for servers this host owns.
+- `/admin-devops:troubleshoot` — track/diagnose/resolve host issues locally.
+- `/admin-devops:wrap-up` — end-of-session ritual (close issues, commit, log).
+- `/admin-devops:adopt-devadmin` — re-run to re-check drift after the skill shape evolves.
+
+Log notable changes with `log-admin-event.sh` / `Log-AdminEvent.ps1` (`OK` level for
+successful adoptions).

--- a/plugins/admin-devops/skills/admin/assets/devadmin/CLAUDE.md.wsl.template
+++ b/plugins/admin-devops/skills/admin/assets/devadmin/CLAUDE.md.wsl.template
@@ -1,0 +1,114 @@
+<!--
+  devadmin workspace CLAUDE.md — WSL template (Claude Code running inside WSL, or a
+  Linux VPS seat). Instantiated by `/admin-devops:adopt-devadmin` into ~/dev/devadmin.
+
+  Placeholders are substituted from the admin profile at adoption time. If you see an
+  un-substituted double-brace placeholder below, this file was copied by hand — re-run
+  /adopt-devadmin to instantiate it properly. Keep the "Retired shapes" table in sync with the skill repo
+  copy: that table IS the migration spec the adopt command reads.
+
+  Template shape version: 1  (bump when the structure below changes so the adopt
+  command's CLAUDE.md shape-diff can flag stale workspaces).
+-->
+# devadmin — {{HOST}} (WSL)
+
+This is the **devadmin workspace** for the WSL/Linux seat on `{{HOST}}`. A Claude Code
+session started here acts as the host-ops seat **`{{AGENT_CODE}}`** against the shared
+Open Engine `devadmin` backlog. It is a **distinct seat** from the host's native
+Windows seat: MCP/OAuth is scoped to this WSL home, so this seat is wired and
+smoke-tested separately.
+
+- **Host:** `{{HOST}}`  ·  **Platform:** `{{PLATFORM}}`  ·  **Workspace:** `{{WORKSPACE_PATH}}`
+- **Agent code (dispatch key):** `{{AGENT_CODE}}`
+- **Host label:** `{{HOST_LABEL}}`
+- **Admin root:** `{{ADMIN_ROOT}}`  ·  **Local issue tracker:** `{{LOCAL_ISSUES_DIR}}`
+- **Template shape version:** 1  ·  **Instantiated:** {{GENERATED}}
+
+## Profile gate first
+
+Every session: confirm the admin profile before any operation. On WSL the profile data
+often lives on the Windows filesystem via a satellite `~/.admin/.env` — the gate
+resolves it.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-}"/skills/admin/scripts/test-admin-profile.sh 2>/dev/null \
+  || { echo "no profile — run /admin-devops:setup-profile"; }
+```
+
+If the script is unavailable, read `~/.admin/.env` for `ADMIN_ROOT` / `ADMIN_DEVICE`
+and load `$ADMIN_ROOT/profiles/$ADMIN_DEVICE.json` directly.
+
+## Open Engine queue contract
+
+The `devadmin` Linear project is the queue; `{{LOCAL_ISSUES_DIR}}` stays the
+authoritative per-host tracker. Linear ⇄ local is reference-only — no mirroring
+obligation.
+
+| Surface | Where |
+| -- | -- |
+| Project | `devadmin` — https://linear.app/evolv3ai/project/devadmin-28dcbcd13f7b |
+| Team | `EVO` / Evolv3ai |
+| Queue label | `agent-instructions` (mandatory) |
+| Host filter | `{{HOST_LABEL}}` |
+| Status ledger | EVO-53 |
+| Routing map | EVO-54 (`Shared cross-host backlog: devadmin`) |
+| Access guide | EVO-58 |
+
+**Claim rule** (process exactly one issue per run): assigned to the operator, label
+`agent-instructions`, title contains `[agent instructions]`, second title bracket is
+`[{{AGENT_CODE}}]`, and state is `Agent Todo` (or a `Agent Needs Input` issue whose
+answer has arrived). Receipts: `AGENT CLAIMED` → `AGENT DONE`, move to `Agent Done`,
+update this seat's `AGENT STATUS` comment on EVO-53.
+
+**Safety:** human approval required for publishing, customer-facing changes,
+destructive ops, billing, credentials, and deploys. Never paste secrets into Linear.
+
+## WSL seat notes
+
+- This seat needs its **own** Linear MCP wiring (`claude mcp add --transport http
+  linear-server https://mcp.linear.app/mcp` then `/mcp` to log in) — the Windows-host
+  user-scope wiring does not cover this WSL home.
+- The smoke test must run **from inside this WSL seat** so OAuth/MCP and the profile
+  are exercised on the right home. It cannot be proxied from the native seat.
+- Keep WSL resources sane via `/admin-devops:admin` (`.wslconfig`, `wsl.conf` assets).
+
+## Local issue tracking
+
+Host-authoritative issues live at `{{LOCAL_ISSUES_DIR}}` and are driven by
+`/admin-devops:troubleshoot`. A routable, still-open local issue may be mirrored up to
+the `devadmin` project (titled `[agent instructions][{{AGENT_CODE}}][task] ...`,
+labeled `agent-instructions` + `{{HOST_LABEL}}`, with a Linear ⇄ local back-reference)
+— the local file stays authoritative. Scrub `.env`-style secrets before mirroring.
+
+## Retired shapes — migration spec
+
+This seat's workspace was consolidated to `{{WORKSPACE_PATH}}`. The folders below are
+**older admin-devops shapes**. If any still exist, move their host-grown content
+(`.env`, `.mcp.json`, `.infisical.json`, `.claude/`, `justfile`, `scripts/`, `tools/`)
+into this workspace, then retire the old folder manually (`rm -rf` after you confirm
+the move — never automated).
+
+`/admin-devops:adopt-devadmin` reads this table to detect drift. Keep it current.
+
+| Retired path | Platform | Shape it came from |
+| -- | -- | -- |
+| `~/dev/admin-wsl` | WSL | WSL admin workspace (pre-devadmin) |
+| `~/wsl-admin` | WSL | early WSL admin workspace |
+| `~/dev/admin-test*` | WSL/Linux | throwaway test workspaces |
+| `~/dev/admin-native` | Linux | early native admin workspace |
+| `~/dev/devops-native` | Linux | early native devops workspace |
+| `D:\admin-native` | Windows side | mirrored Windows admin workspace (if on /mnt/d) |
+| `D:\_admin` | Windows side | underscore-prefixed admin workspace |
+| `D:\admin-test` | Windows side | throwaway test workspace |
+
+Current canonical workspace: **`{{WORKSPACE_PATH}}`**.
+
+## Day-to-day
+
+- `/admin-devops:admin` — local installs, MCP wiring, dev-env config for this seat.
+- `/admin-devops:devops` — remote infra for servers this seat owns.
+- `/admin-devops:troubleshoot` — track/diagnose/resolve host issues locally.
+- `/admin-devops:wrap-up` — end-of-session ritual (close issues, commit, log).
+- `/admin-devops:adopt-devadmin` — re-run to re-check drift after the skill shape evolves.
+
+Log notable changes with `log-admin-event.sh` (`OK` level for successful adoptions).

--- a/plugins/admin-devops/skills/admin/assets/devadmin/README.md
+++ b/plugins/admin-devops/skills/admin/assets/devadmin/README.md
@@ -1,0 +1,51 @@
+# devadmin workspace templates
+
+Templates the `/admin-devops:adopt-devadmin` command instantiates into a host's
+**devadmin workspace** — the folder a Claude Code session runs from to act as that
+host's shared-host-ops seat against the Open Engine `devadmin` Linear backlog.
+
+These graduated out of the per-host staging location
+(`~/.admin/templates/devadmin/` on WOPR3) and are now the single source of truth.
+Edit them here; the adopt command reads them from the installed plugin.
+
+## Files
+
+| File | Used when | Instantiated to |
+| -- | -- | -- |
+| `CLAUDE.md.native.template` | Windows native, macOS, or bare-Linux host seat | Windows: `D:\devadmin\CLAUDE.md` · macOS/Linux: `~/dev/devadmin/CLAUDE.md` |
+| `CLAUDE.md.wsl.template` | Claude Code inside WSL, or a Linux VPS seat | `~/dev/devadmin/CLAUDE.md` |
+
+The adopt command picks the template from the profile's `ADMIN_PLATFORM`
+(`windows`/`macos`/`linux` → native, `wsl` → wsl).
+
+## Placeholders
+
+Substituted from the admin profile (`~/.admin/.env` + `$ADMIN_ROOT/profiles/<device>.json`)
+at adoption time. The `devadmin-adopt` script emits these as a JSON `placeholders`
+object; the command performs the substitution.
+
+| Placeholder | Source | Example |
+| -- | -- | -- |
+| `{{HOST}}` | `ADMIN_DEVICE` (display) | `WOPR3` |
+| `{{HOST_SLUG}}` | host slug (lowercased, de-suffixed) | `wopr3` |
+| `{{HOST_LABEL}}` | `host:<slug>` | `host:wopr3` |
+| `{{AGENT_CODE}}` | routing-map seat code for this runtime | `wopr3-claude-cli` / `wopr3-claude-cli-wsl` |
+| `{{PLATFORM}}` | `ADMIN_PLATFORM` | `windows` / `wsl` / `linux` / `macos` |
+| `{{WORKSPACE_PATH}}` | canonical workspace for the platform | `D:\devadmin` / `~/dev/devadmin` |
+| `{{ADMIN_ROOT}}` | `ADMIN_ROOT` | `~/.admin` / `C:\Users\Owner\.admin` |
+| `{{LOCAL_ISSUES_DIR}}` | `$ADMIN_ROOT/issues` | `~/.admin/issues` |
+| `{{GENERATED}}` | adoption date (ISO, supplied by the command) | `2026-07-01` |
+
+## Shape version
+
+Each template carries a `Template shape version` in its header comment and body. The
+adopt command's CLAUDE.md shape-diff compares an existing workspace's version (and a
+content hash) against the current template to flag a stale workspace that needs
+re-instantiation. **Bump the version when the template structure changes.**
+
+## Retired-path table = migration spec
+
+The "Retired shapes" table in each template is the canonical list of older
+admin-devops workspace shapes. `/admin-devops:adopt-devadmin` reads it to detect drift
+and offer migration. Adding a row here is how you teach the adopt command about a new
+retired shape — keep it current and the migration command stays current.

--- a/plugins/admin-devops/skills/admin/references/devadmin-onboarding.md
+++ b/plugins/admin-devops/skills/admin/references/devadmin-onboarding.md
@@ -1,0 +1,140 @@
+# devadmin onboarding & migration
+
+Reference for `/admin-devops:adopt-devadmin` — how a host is brought onto (or migrated
+to) the shared Open Engine `devadmin` host-ops backlog. The command is the executable
+form of this document; this is the why and the decision tree.
+
+## What "adopted" means
+
+A host is **adopted** when all of the following are true:
+
+| Surface | In place when… |
+| -- | -- |
+| Linear project | `devadmin` project exists (`https://linear.app/evolv3ai/project/devadmin-28dcbcd13f7b`) |
+| Host label | `host:<slug>` label exists in the EVO team |
+| Seat | this runtime's agent code is on the EVO-54 routing map and its EVO-53 ledger entry says `installed` (`online`) |
+| Workspace | canonical workspace exists (`D:\devadmin` native · `~/dev/devadmin` WSL/Linux) with a current-shape `CLAUDE.md` |
+| Routing map | the host has a row under EVO-54 → *Shared cross-host backlog: `devadmin`* and the seat status is `online` |
+
+Idempotency target: on an already-adopted host the command finds all five in place
+and reports **nothing to do**.
+
+## The two migration sources
+
+The command covers drift from two directions:
+
+**(a) Other ticket systems → devadmin local tracker.** v1 understands the local
+`~/.admin/issues/*.md` files (the `/troubleshoot` format) and GitHub Issues (admin-devops
+already integrates `gh` per `/wrap-up`). Routable, still-open items can be *mirrored up*
+to the `devadmin` Linear project; the local file stays authoritative. v2 can plug in
+others (Jira, a Linear team, plain markdown).
+
+**(b) Older admin-devops skill shapes → current shape.** Driven entirely by
+**retired-path detection** plus **CLAUDE.md shape diff**. The retired-path table in the
+CLAUDE.md template (`assets/devadmin/CLAUDE.md.*.template`) *is* the migration spec:
+keeping that table current keeps this command current. No per-shape migration code —
+add a row, the detector picks it up.
+
+## Flow
+
+```
+            ┌─────────────────────────────────────────────────────────┐
+            │ 0. Profile gate (mandatory) — no profile → /setup-profile│
+            └───────────────────────────┬─────────────────────────────┘
+                                        │
+            ┌───────────────────────────▼─────────────────────────────┐
+            │ 1. Detect current shape (READ-ONLY)                      │
+            │    • local: devadmin-adopt.sh / .ps1                     │
+            │        - workspace + CLAUDE.md shape version             │
+            │        - retired paths on disk                           │
+            │        - local issue census (open/resolved)             │
+            │        - profile → placeholders                          │
+            │    • Linear (MCP): project? host:<slug> label?           │
+            │        seat on EVO-54? EVO-53 status == installed?       │
+            └───────────────────────────┬─────────────────────────────┘
+                                        │
+            ┌───────────────────────────▼─────────────────────────────┐
+            │ 2. Diff report — in place ✓ vs missing ✗                 │
+            └───────────────────────────┬─────────────────────────────┘
+                                        │
+        ┌───────────────────────────────▼───────────────────────────────┐
+        │ 3. Walk MISSING steps, AskUserQuestion checkpoint at each branch│
+        │    a. Linear surface  — create project? create host label?     │
+        │    b. Seat            — not online → run smoke test (in-seat)   │
+        │    c. Workspace       — scaffold from template; offer to move   │
+        │                         host-grown content from old folder      │
+        │    d. Issue migration — mirror routable+open local issues up    │
+        │                         (scrub secrets; local stays source)     │
+        │    e. Old folders     — enumerate; STAGE for manual rm -rf only │
+        └───────────────────────────────┬───────────────────────────────┘
+                                        │
+            ┌───────────────────────────▼─────────────────────────────┐
+            │ 4. Update routing map (EVO-54) — add host row; → online   │
+            │ 5. Log OK event (log-admin-event.sh / Log-AdminEvent.ps1) │
+            │ 6. Report — URLs/paths + manual TODO checklist            │
+            └─────────────────────────────────────────────────────────┘
+```
+
+## Decision tree
+
+```
+Is the devadmin project reachable via Linear MCP?
+├─ no  → STOP. Wire Linear MCP for THIS seat first (see EVO-58 / open-engine-admin).
+└─ yes →
+   Does host:<slug> label exist?
+   ├─ no  → [checkpoint] create it (EVO team).
+   └─ yes →
+      Does the canonical workspace exist with current CLAUDE.md shape?
+      ├─ no workspace            → [checkpoint] scaffold from template.
+      ├─ workspace, stale shape  → [checkpoint] re-instantiate CLAUDE.md (back up old).
+      └─ workspace, current      → ok.
+      Any retired-path folders on disk?
+      ├─ yes → [checkpoint] offer to MOVE host-grown content into workspace,
+      │         then STAGE old folder for manual deletion (never auto rm).
+      └─ no  → ok.
+      Local issues present and untracked in Linear?
+      ├─ yes → [checkpoint] offer to mirror routable+open ones up (scrub secrets).
+      └─ no  → ok.
+      Is this seat's EVO-53 status `installed`?
+      ├─ no  → run the in-seat smoke test end-to-end (cannot be proxied).
+      └─ yes → ok.
+      → Update EVO-54 row to `online`, log OK, report.
+```
+
+## Runtime → template → workspace
+
+| Profile `ADMIN_PLATFORM` | Template | Workspace | Suggested agent code |
+| -- | -- | -- | -- |
+| `windows` | `CLAUDE.md.native.template` | `D:\devadmin` | `<slug>-claude-cli` |
+| `macos` / `linux` (native) | `CLAUDE.md.native.template` | `~/dev/devadmin` | `<slug>-claude-cli` |
+| `wsl` | `CLAUDE.md.wsl.template` | `~/dev/devadmin` | `<slug>-claude-cli-wsl` |
+
+The suggested agent code is a *starting point*. Always confirm it against the EVO-54
+roster — an existing ledger code wins (per the agent-code convention in EVO-58). WSL is
+a **distinct seat** from the host's native seat: separate MCP/OAuth, separate smoke
+test, separate code.
+
+Host slug map: `WOPR3`→`wopr3`, `DELTABOT`→`delta`, `CASATEN`/`CASA`→`casa`; otherwise
+the lowercased alphanumeric device name.
+
+## Guardrails (enforced by the command)
+
+- **Never auto-delete a retired folder.** Move content, then output a `rm -rf` /
+  `Remove-Item` checklist for the user to run after they confirm.
+- **Never paste secrets into Linear.** Scrub `.env`-style content from any local issue
+  body before mirroring it up.
+- **Profile changes require confirmation.** Never silently rewrite preferences from
+  detected state.
+- **The smoke test runs in the target seat.** MCP/OAuth must be exercised on the right
+  host/profile/WSL home; the command cannot proxy a smoke test from another seat. When
+  the command *is* running in the target seat, running the claim→hello→done loop inline
+  is correct (the "admin-is-seat" case from `open-engine-admin`).
+
+## Related
+
+- Routing map: EVO-54 → *Shared cross-host backlog: `devadmin`* (the section is the spec).
+- Status ledger format: EVO-53.
+- Access / contract: EVO-58.
+- Open Engine control-plane patterns: `open-engine-skills` → `open-engine-admin` skill.
+- Templates + placeholders: `assets/devadmin/README.md`.
+- Local issue tracking: `/admin-devops:troubleshoot`.

--- a/plugins/admin-devops/skills/admin/scripts/devadmin-adopt.ps1
+++ b/plugins/admin-devops/skills/admin/scripts/devadmin-adopt.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+    Read-only shape detection for /admin-devops:adopt-devadmin (Windows-native seats).
+
+.DESCRIPTION
+    Detects the local (filesystem + profile + local-issue) half of a host's devadmin
+    adoption state on a Windows-native seat (workspace D:\devadmin). The Linear half
+    (project/label/seat/ledger) is checked by the command via MCP — this script never
+    touches the network and never mutates. Emits a single JSON object matching the
+    bash sibling (devadmin-adopt.sh) so the command consumes either identically.
+
+.PARAMETER Pretty
+    Emit indented JSON (default is already indented; kept for parity with the shell flag).
+
+.EXAMPLE
+    pwsh -NoProfile -File devadmin-adopt.ps1
+#>
+[CmdletBinding()]
+param([switch]$Pretty)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot   = Split-Path -Parent $ScriptDir              # ...\skills\admin
+$TemplateDir = Join-Path $SkillRoot 'assets\devadmin'
+$Satellite   = Join-Path $env:USERPROFILE '.admin\.env'
+
+function Read-EnvVar([string]$Name, [string]$File) {
+    if (-not (Test-Path -LiteralPath $File)) { return '' }
+    $line = Select-String -LiteralPath $File -Pattern "^$([regex]::Escape($Name))=" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $line) { return '' }
+    return ($line.Line -replace "^$([regex]::Escape($Name))=", '')
+}
+
+function Get-HostSlug([string]$Device) {
+    $d = $Device.ToLower()
+    switch -Regex ($d) {
+        '^wopr3'           { return 'wopr3' }
+        '^(delta|deltabot)'{ return 'delta' }
+        '^(casa|casaten)'  { return 'casa' }
+        default            { return ($d -replace '[^a-z0-9]', '') }
+    }
+}
+
+# --- resolve profile (read-only) -------------------------------------------
+$AdminRoot = if ($env:ADMIN_ROOT)   { $env:ADMIN_ROOT }   else { Read-EnvVar 'ADMIN_ROOT'   $Satellite }
+$Device    = if ($env:ADMIN_DEVICE) { $env:ADMIN_DEVICE } else { Read-EnvVar 'ADMIN_DEVICE' $Satellite }
+$Platform  = if ($env:ADMIN_PLATFORM){ $env:ADMIN_PLATFORM } else { Read-EnvVar 'ADMIN_PLATFORM' $Satellite }
+if (-not $AdminRoot) { $AdminRoot = Join-Path $env:USERPROFILE '.admin' }
+if (-not $Device)    { $Device    = $env:COMPUTERNAME }
+if (-not $Platform)  { $Platform  = 'windows' }
+
+$ProfilePath   = Join-Path $AdminRoot ("profiles\{0}.json" -f $Device)
+$ProfileExists = Test-Path -LiteralPath $ProfilePath
+$Slug          = Get-HostSlug $Device
+$HostLabel     = "host:$Slug"
+$IssuesDir     = Join-Path $AdminRoot 'issues'
+
+# Windows-native always uses the native template + D:\devadmin workspace.
+$TemplateKind  = 'native'
+$TemplateFile  = Join-Path $TemplateDir 'CLAUDE.md.native.template'
+$Workspace     = 'D:\devadmin'
+$SuggestedCode = "$Slug-claude-cli"
+
+# --- workspace + CLAUDE.md shape -------------------------------------------
+$WsExists       = Test-Path -LiteralPath $Workspace
+$WsClaude       = Join-Path $Workspace 'CLAUDE.md'
+$WsClaudeExists = Test-Path -LiteralPath $WsClaude
+
+function Get-ShapeVersion([string]$File) {
+    if (-not (Test-Path -LiteralPath $File)) { return '' }
+    $m = Select-String -LiteralPath $File -Pattern 'Template shape version: (\d+)' -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $m) { return '' }
+    return $m.Matches[0].Groups[1].Value
+}
+
+$TemplateShape = Get-ShapeVersion $TemplateFile
+if (-not $TemplateShape) { $TemplateShape = 'unknown' }
+$WsShape = ''
+$WsStale = 'unknown'
+if ($WsClaudeExists) {
+    $WsShape = Get-ShapeVersion $WsClaude
+    if (-not $WsShape)                  { $WsStale = 'true' }   # no marker = pre-template shape
+    elseif ($WsShape -eq $TemplateShape){ $WsStale = 'false' }
+    else                                { $WsStale = 'true' }
+}
+
+# --- retired-path scan (read-only) -----------------------------------------
+$RetiredCandidates = @(
+    'D:\admin-native', 'D:\devops-native', 'D:\admin', 'D:\_admin', 'D:\admin-test',
+    'D:\devadmin-old', 'C:\admin-native'
+)
+$RetiredFound = @()
+foreach ($p in $RetiredCandidates) { if (Test-Path -LiteralPath $p) { $RetiredFound += $p } }
+foreach ($g in (Get-ChildItem -Path 'D:\' -Filter 'admin-test*' -Directory -ErrorAction SilentlyContinue)) {
+    if ($RetiredFound -notcontains $g.FullName) { $RetiredFound += $g.FullName }
+}
+
+# --- local issue census -----------------------------------------------------
+$Total = 0; $Open = 0; $Resolved = 0
+if (Test-Path -LiteralPath $IssuesDir) {
+    $files = Get-ChildItem -LiteralPath $IssuesDir -File -ErrorAction SilentlyContinue |
+             Where-Object { $_.Name -match '^(ISSUE-.*|issue_.*)\.md$' }
+    foreach ($f in $files) {
+        $Total++
+        $statusLine = Select-String -LiteralPath $f.FullName -Pattern '^status:' -ErrorAction SilentlyContinue | Select-Object -First 1
+        $st = ''
+        if ($statusLine) { $st = ($statusLine.Line -replace '^status:\s*', '').Trim() }
+        if ($st -match '^(resolved|closed|done)$') { $Resolved++ } else { $Open++ }
+    }
+}
+
+# --- assemble JSON ----------------------------------------------------------
+$result = [ordered]@{
+    host               = $Device
+    hostSlug           = $Slug
+    hostLabel          = $HostLabel
+    platform           = $Platform
+    suggestedAgentCode = $SuggestedCode
+    profile            = [ordered]@{ exists = [bool]$ProfileExists; path = $ProfilePath; adminRoot = $AdminRoot }
+    workspace          = [ordered]@{
+        path     = $Workspace
+        exists   = [bool]$WsExists
+        claudeMd = [ordered]@{ exists = [bool]$WsClaudeExists; shapeVersion = $WsShape; stale = $WsStale }
+    }
+    template           = [ordered]@{ kind = $TemplateKind; file = $TemplateFile; shapeVersion = $TemplateShape }
+    retiredPaths       = @($RetiredFound)
+    localIssues        = [ordered]@{ dir = $IssuesDir; total = $Total; open = $Open; resolved = $Resolved }
+    placeholders       = [ordered]@{
+        HOST             = $Device
+        HOST_SLUG        = $Slug
+        HOST_LABEL       = $HostLabel
+        AGENT_CODE       = $SuggestedCode
+        PLATFORM         = $Platform
+        WORKSPACE_PATH   = $Workspace
+        ADMIN_ROOT       = $AdminRoot
+        LOCAL_ISSUES_DIR = $IssuesDir
+        GENERATED        = (Get-Date -Format 'yyyy-MM-dd')
+    }
+}
+
+$result | ConvertTo-Json -Depth 6

--- a/plugins/admin-devops/skills/admin/scripts/devadmin-adopt.sh
+++ b/plugins/admin-devops/skills/admin/scripts/devadmin-adopt.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# =============================================================================
+# devadmin-adopt.sh — read-only shape detection for /admin-devops:adopt-devadmin
+# =============================================================================
+# Detects the local (filesystem + profile + local-issue) half of a host's
+# devadmin adoption state. The Linear half (project/label/seat/ledger) is checked
+# by the command via MCP — this script never touches the network and never mutates.
+#
+# Bash side covers WSL / Linux / macOS seats (workspace ~/dev/devadmin).
+# The PowerShell sibling (devadmin-adopt.ps1) covers Windows-native seats (D:\devadmin).
+#
+# Output: a single JSON object on stdout describing what is in place vs missing,
+# plus a `placeholders` object the command uses to instantiate the CLAUDE.md
+# template. Read-only: no writes, no deletes, no network.
+#
+# Usage:
+#   ./devadmin-adopt.sh                 # detect, print JSON
+#   ./devadmin-adopt.sh --pretty        # re-validate through jq when available
+# =============================================================================
+
+set -eo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+SKILL_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)          # .../skills/admin
+TEMPLATE_DIR="${SKILL_ROOT}/assets/devadmin"
+SATELLITE_ENV="${HOME}/.admin/.env"
+PRETTY=0
+[[ "${1:-}" == "--pretty" ]] && PRETTY=1
+emit() { if [[ $PRETTY -eq 1 ]] && command -v jq >/dev/null 2>&1; then jq .; else cat; fi; }
+
+# --- helpers ----------------------------------------------------------------
+
+read_env_var() {  # $1 var, $2 file
+    grep "^${1}=" "${2}" 2>/dev/null | head -1 | cut -d'=' -f2- || true
+}
+
+json_escape() {   # escape a string for embedding in JSON
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    printf '%s' "$s"
+}
+
+# Map a device name to the short host slug used by the routing map / host:* labels.
+host_slug() {
+    local dev_lc
+    dev_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    case "$dev_lc" in
+        wopr3*)              echo "wopr3" ;;
+        delta*|deltabot*)    echo "delta" ;;
+        casa*|casaten*)      echo "casa" ;;
+        *)                   printf '%s' "$dev_lc" | tr -cd 'a-z0-9' ;;
+    esac
+}
+
+# --- resolve profile (read-only) -------------------------------------------
+
+ADMIN_ROOT_R="${ADMIN_ROOT:-}"
+DEVICE_R="${ADMIN_DEVICE:-}"
+PLATFORM_R="${ADMIN_PLATFORM:-}"
+if [[ -f "$SATELLITE_ENV" ]]; then
+    [[ -z "$ADMIN_ROOT_R" ]] && ADMIN_ROOT_R=$(read_env_var ADMIN_ROOT "$SATELLITE_ENV")
+    [[ -z "$DEVICE_R"     ]] && DEVICE_R=$(read_env_var ADMIN_DEVICE "$SATELLITE_ENV")
+    [[ -z "$PLATFORM_R"   ]] && PLATFORM_R=$(read_env_var ADMIN_PLATFORM "$SATELLITE_ENV")
+fi
+ADMIN_ROOT_R="${ADMIN_ROOT_R:-${HOME}/.admin}"
+DEVICE_R="${DEVICE_R:-$(hostname)}"
+if [[ -z "$PLATFORM_R" ]]; then
+    if grep -qi microsoft /proc/version 2>/dev/null; then PLATFORM_R="wsl"
+    elif [[ "$(uname -s)" == "Darwin" ]]; then PLATFORM_R="macos"
+    else PLATFORM_R="linux"; fi
+fi
+PROFILE_PATH="${ADMIN_ROOT_R}/profiles/${DEVICE_R}.json"
+PROFILE_EXISTS="false"; [[ -f "$PROFILE_PATH" ]] && PROFILE_EXISTS="true"
+
+SLUG=$(host_slug "$DEVICE_R")
+HOST_LABEL="host:${SLUG}"
+ISSUES_DIR="${ADMIN_ROOT_R}/issues"
+
+# Template + workspace selection. Bash side is always the "wsl" template family.
+TEMPLATE_KIND="wsl"
+TEMPLATE_FILE="${TEMPLATE_DIR}/CLAUDE.md.${TEMPLATE_KIND}.template"
+WORKSPACE="${HOME}/dev/devadmin"
+if [[ "$PLATFORM_R" == "wsl" ]]; then
+    SUGGESTED_CODE="${SLUG}-claude-cli-wsl"
+else
+    SUGGESTED_CODE="${SLUG}-claude-cli"   # bare linux/macos native seat
+    TEMPLATE_KIND="native"
+    TEMPLATE_FILE="${TEMPLATE_DIR}/CLAUDE.md.native.template"
+fi
+
+# --- workspace + CLAUDE.md shape -------------------------------------------
+
+WS_EXISTS="false";  [[ -d "$WORKSPACE" ]] && WS_EXISTS="true"
+WS_CLAUDE="${WORKSPACE}/CLAUDE.md"
+WS_CLAUDE_EXISTS="false"; [[ -f "$WS_CLAUDE" ]] && WS_CLAUDE_EXISTS="true"
+
+TEMPLATE_SHAPE=$(grep -oE 'Template shape version: [0-9]+' "$TEMPLATE_FILE" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
+TEMPLATE_SHAPE="${TEMPLATE_SHAPE:-unknown}"
+WS_SHAPE=""
+WS_SHAPE_STALE="unknown"
+if [[ "$WS_CLAUDE_EXISTS" == "true" ]]; then
+    WS_SHAPE=$(grep -oE 'Template shape version: [0-9]+' "$WS_CLAUDE" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
+    if [[ -z "$WS_SHAPE" ]]; then WS_SHAPE_STALE="true"     # no version marker = pre-template shape
+    elif [[ "$WS_SHAPE" == "$TEMPLATE_SHAPE" ]]; then WS_SHAPE_STALE="false"
+    else WS_SHAPE_STALE="true"; fi
+fi
+
+# --- retired-path scan (read-only) -----------------------------------------
+# Candidate older shapes for this seat. Windows-side paths are checked under
+# /mnt/d when this is a WSL seat that can see the Windows drive.
+RETIRED_CANDIDATES=(
+    "${HOME}/dev/admin-wsl"
+    "${HOME}/wsl-admin"
+    "${HOME}/dev/admin-native"
+    "${HOME}/dev/devops-native"
+    "/mnt/d/admin-native"
+    "/mnt/d/devops-native"
+    "/mnt/d/admin"
+    "/mnt/d/_admin"
+    "/mnt/d/admin-test"
+)
+RETIRED_FOUND=()
+for p in "${RETIRED_CANDIDATES[@]}"; do
+    [[ -e "$p" ]] && RETIRED_FOUND+=("$p")
+done
+# globbed throwaway test dirs
+for g in "${HOME}/dev/"admin-test*; do
+    [[ -e "$g" ]] && RETIRED_FOUND+=("$g")
+done
+
+# --- local issue census -----------------------------------------------------
+# Supports both the /troubleshoot naming (issue_YYYYMMDD_*.md) and the
+# devadmin ISSUE-00xx.md convention. Counts open vs resolved by frontmatter status.
+ISSUES_TOTAL=0; ISSUES_OPEN=0; ISSUES_RESOLVED=0
+if [[ -d "$ISSUES_DIR" ]]; then
+    while IFS= read -r -d '' f; do
+        ISSUES_TOTAL=$((ISSUES_TOTAL + 1))
+        st=$(grep -m1 -E '^status:' "$f" 2>/dev/null | sed -E 's/^status:[[:space:]]*//' | tr -d '[:space:]' || true)
+        case "$st" in
+            resolved|closed|done) ISSUES_RESOLVED=$((ISSUES_RESOLVED + 1)) ;;
+            *)                    ISSUES_OPEN=$((ISSUES_OPEN + 1)) ;;
+        esac
+    done < <(find "$ISSUES_DIR" -maxdepth 1 -type f \( -iname 'ISSUE-*.md' -o -iname 'issue_*.md' \) -print0 2>/dev/null)
+fi
+
+# --- assemble JSON ----------------------------------------------------------
+
+retired_json="["
+first=1
+for p in "${RETIRED_FOUND[@]}"; do
+    [[ $first -eq 0 ]] && retired_json+=","
+    retired_json+="\"$(json_escape "$p")\""
+    first=0
+done
+retired_json+="]"
+
+GEN_DATE=$(date +%Y-%m-%d 2>/dev/null || echo "")
+
+emit <<JSON
+{
+  "host": "$(json_escape "$DEVICE_R")",
+  "hostSlug": "$(json_escape "$SLUG")",
+  "hostLabel": "$(json_escape "$HOST_LABEL")",
+  "platform": "$(json_escape "$PLATFORM_R")",
+  "suggestedAgentCode": "$(json_escape "$SUGGESTED_CODE")",
+  "profile": { "exists": ${PROFILE_EXISTS}, "path": "$(json_escape "$PROFILE_PATH")", "adminRoot": "$(json_escape "$ADMIN_ROOT_R")" },
+  "workspace": {
+    "path": "$(json_escape "$WORKSPACE")",
+    "exists": ${WS_EXISTS},
+    "claudeMd": { "exists": ${WS_CLAUDE_EXISTS}, "shapeVersion": "$(json_escape "$WS_SHAPE")", "stale": "$(json_escape "$WS_SHAPE_STALE")" }
+  },
+  "template": { "kind": "$(json_escape "$TEMPLATE_KIND")", "file": "$(json_escape "$TEMPLATE_FILE")", "shapeVersion": "$(json_escape "$TEMPLATE_SHAPE")" },
+  "retiredPaths": ${retired_json},
+  "localIssues": { "dir": "$(json_escape "$ISSUES_DIR")", "total": ${ISSUES_TOTAL}, "open": ${ISSUES_OPEN}, "resolved": ${ISSUES_RESOLVED} },
+  "placeholders": {
+    "HOST": "$(json_escape "$DEVICE_R")",
+    "HOST_SLUG": "$(json_escape "$SLUG")",
+    "HOST_LABEL": "$(json_escape "$HOST_LABEL")",
+    "AGENT_CODE": "$(json_escape "$SUGGESTED_CODE")",
+    "PLATFORM": "$(json_escape "$PLATFORM_R")",
+    "WORKSPACE_PATH": "$(json_escape "$WORKSPACE")",
+    "ADMIN_ROOT": "$(json_escape "$ADMIN_ROOT_R")",
+    "LOCAL_ISSUES_DIR": "$(json_escape "$ISSUES_DIR")",
+    "GENERATED": "$(json_escape "$GEN_DATE")"
+  }
+}
+JSON


### PR DESCRIPTION
Linear: [EVO-93](https://linear.app/evolv3ai/issue/EVO-93)

Graduates the per-host **devadmin** onboarding/migration flow (done manually for WOPR3 on 2026-06-30) into a first-class `/admin-devops:adopt-devadmin` command.

## What's here

| File | Purpose |
| -- | -- |
| `commands/adopt-devadmin.md` | The command: profile gate → read-only detect → diff report → `AskUserQuestion`-checkpointed walk → EVO-54 routing update → OK log → final report. Idempotent. |
| `skills/admin/assets/devadmin/CLAUDE.md.native.template` | Workspace `CLAUDE.md` for Windows-native / macOS / bare-Linux seats (`D:\devadmin` / `~/dev/devadmin`). |
| `skills/admin/assets/devadmin/CLAUDE.md.wsl.template` | Workspace `CLAUDE.md` for WSL / Linux-VPS seats (`~/dev/devadmin`). |
| `skills/admin/assets/devadmin/README.md` | Template + placeholder reference, shape-version policy. |
| `skills/admin/references/devadmin-onboarding.md` | Flow, ASCII diagram, decision tree, migration sources. |
| `skills/admin/scripts/devadmin-adopt.sh` / `.ps1` | Read-only shape detector → JSON (workspace + CLAUDE.md shape diff, retired-path scan, local-issue census, profile→placeholders). No network, no mutation. |
| `SKILL.md`, `GUIDE.md` | Wire the command/reference into discovery surfaces. |

## Design notes
- **Retired-path table = migration spec.** Each template carries the table of older admin-devops shapes; the detector reads it. Add a row to teach the command a new retired shape — no per-shape code.
- **Templates moved into the repo** (`skills/admin/assets/devadmin/`), off the WOPR3 staging path `~/.admin/templates/devadmin/`.
- **Guardrails enforced in the command**: never auto-delete a retired folder (stage a manual `rm -rf` checklist), scrub `.env` secrets before mirroring issues to Linear, confirm before profile changes, run the smoke test in the target seat (no proxying).

## Validation
- `devadmin-adopt.sh`: `bash -n` clean; run on this Linux host emits valid JSON; correctly reports a "nothing set up" host (no workspace / retired paths / local issues).
- Both templates render with **zero** leftover `{{placeholders}}` when substituted from the detector's `placeholders` object.
- `devadmin-adopt.ps1`: authored to the same JSON schema but **not executed** — no `pwsh` on the authoring host. Needs a run on a Windows seat before relying on it.

## Follow-up (operational, post-merge — out of band from this PR)
Per the EVO-93 acceptance criteria, these require running on the real estate and a plugin refresh:
- [ ] Verify `/admin-devops:adopt-devadmin` is discoverable from `claude /` after refresh.
- [ ] Run on a host with nothing set up (full scaffold) and on an already-adopted host (nothing-to-do).
- [ ] Adopt at least one non-WOPR3 host (DELTABOT or CASATEN) via the command and reflect it in EVO-54.
- [ ] Validate `devadmin-adopt.ps1` on a Windows seat.
- [ ] Remove the WOPR3 staging templates once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)